### PR TITLE
レイヤーに合わせた戻り値を返すように修正する

### DIFF
--- a/domain/model/book/book.go
+++ b/domain/model/book/book.go
@@ -20,5 +20,8 @@ type Book struct {
 	PublishedMonth int       `json:"published_month"`
 	PublishedDate  int       `json:"published_date"`
 	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+func NewBook() {
+	
 }

--- a/domain/model/book/book.go
+++ b/domain/model/book/book.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Book : 本のドメインモデル
-// TODO: ドメインモデルをORMのEntityの用に使ってしまっているから、persistence/userbook/entity.go?を作成する。
+// TODO: ドメインモデルをORMのEntityの用に使ってしまっているから、datasource/userbook/entity.go?を作成する。
 // NOTE: Isbn_10カラムを取得する場合フィールドをIsbn_10にする必要がある(=>Isbn10では取得できない)
 type Book struct {
 	Id             int       `json:"id" gorm:"primaryKey;"`

--- a/domain/model/book/book_repository.go
+++ b/domain/model/book/book_repository.go
@@ -2,4 +2,5 @@ package book
 
 type BookRepository interface {
 	FindOrCreateByGoogleBooksId(GoogleBooksId string) Book
+	FindAllByUserId(userId int) ([]Book, error)
 }

--- a/domain/model/book/book_repository.go
+++ b/domain/model/book/book_repository.go
@@ -1,6 +1,7 @@
 package book
 
 type BookRepository interface {
-	FindOrCreateByGoogleBooksId(GoogleBooksId string) Book
 	FindAllByUserId(userId int) ([]Book, error)
+	FindOneByGoogleBooksId(GoogleBooksId string) (Book, error)
+	Save(book Book) error
 }

--- a/domain/model/searched_books/google_books_api/client_interface.go
+++ b/domain/model/searched_books/google_books_api/client_interface.go
@@ -1,7 +1,7 @@
 package google_books_api
 
-// ResponseBodyFromGoogleBooksAPI : GoogleBooksAPIを叩いた時のJSONレスポンスを格納する構造体
-type ResponseBodyFromGoogleBooksAPI struct {
+// ResponseBodyFromGoogleBooksApi : GoogleBooksAPIを叩いた時のJSONレスポンスを格納する構造体
+type ResponseBodyFromGoogleBooksApi struct {
 	Items []Item `json:"items"`
 }
 
@@ -22,4 +22,8 @@ type VolumeInfo struct {
 type IndustryIdentifier struct {
 	Type       string `json:"type"`
 	Identifier string `json:"identifier"`
+}
+
+type GoogleBooksApiClientInterface interface {
+	SendRequest(searchWord string) (ResponseBodyFromGoogleBooksApi, error)
 }

--- a/domain/model/user/user.go
+++ b/domain/model/user/user.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TODO: アプリケーション側でunique制約を付けるには？（DBにアクセスする必要が出てくる）
-// TODO: ドメインモデルをORMのEntityの用に使ってしまっているから、 persistence/user/entity.go?を作成する。
+// TODO: ドメインモデルをORMのEntityの用に使ってしまっているから、 datasource/user/entity.go?を作成する。
 type User struct {
 	Id        int         `json:"id" gorm:"primaryKey"`
 	UserName  string      `json:"user_name" validate:"required,max=255"`

--- a/domain/model/user/user_repository.go
+++ b/domain/model/user/user_repository.go
@@ -4,7 +4,7 @@ package user
 type UserRepository interface {
 	// *型名でポイント型になる
 	// *型名でUser型へのポイント型
-	Create(user User) (User, error)
+	Create(user User) error
 	FindOneByEmail(email string) (User, error)
-	FindOne(userId int) User
+	FindOne(userId int) (User, error)
 }

--- a/domain/model/userbook/memo.go
+++ b/domain/model/userbook/memo.go
@@ -1,0 +1,25 @@
+package userbook
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// Memo : 本のメモ
+type Memo struct {
+	Value string
+}
+
+// メモの最大文字数
+const maxCount = 255
+
+// NewMemo : コンストラクター
+func NewMemo(value string) (Memo, error) {
+	memoCount := utf8.RuneCountInString(value)
+
+	if memoCount > maxCount {
+		return Memo{}, fmt.Errorf("メモは255文字以下で入力ください。")
+	}
+
+	return Memo{value}, nil
+}

--- a/domain/model/userbook/status.go
+++ b/domain/model/userbook/status.go
@@ -1,5 +1,14 @@
 package userbook
 
+import (
+	"fmt"
+)
+
+// Status : 本の読書ステータス
+type Status struct {
+	Value int
+}
+
 // 本の読書ステータスのEnum
 const (
 	// WantToRead : 読みたい（= 1）
@@ -10,16 +19,30 @@ const (
 	DONE
 )
 
+// NewStatus : コンストラクター
+func NewStatus(value int) (Status, error) {
+	// TODO: Contain関数を作成する https://zenn.dev/glassonion1/articles/7c7830a269909c
+	isValid := func() bool {
+		for _, bookStatus := range getBookStatuses() {
+			if value == bookStatus {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !isValid() {
+		return Status{}, fmt.Errorf("読書ステータスの値が不正です。 status: %d", value)
+	}
+
+	return Status{value}, nil
+}
+
 // GetBookStatuses : 本の読書ステータス一覧を取得する
-func GetBookStatuses() []int {
+func getBookStatuses() []int {
 	return []int{
 		WantToRead,
 		READING,
 		DONE,
 	}
-}
-
-// Status : ユーザーが登録している本の読書ステータス
-type Status struct {
-	Value int `json:"status"`
 }

--- a/domain/model/userbook/user_book.go
+++ b/domain/model/userbook/user_book.go
@@ -6,12 +6,12 @@ import (
 )
 
 type UserBook struct {
-	Id        int       `json:"id" gorm:"primaryKey"`
-	UserId    int       `json:"user_id"`
-	BookId    int       `json:"book_id"`
-	Status    int       `json:"status"`
-	Memo      string    `json:"memo"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	Book      book.Book `json:"user_book"`
+	Id        int
+	UserId    int
+	BookId    int
+	Status    int
+	Memo      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	Book      book.Book
 }

--- a/domain/model/userbook/user_book.go
+++ b/domain/model/userbook/user_book.go
@@ -2,6 +2,7 @@ package userbook
 
 import (
 	"github.com/ryota1116/stacked_books/domain/model/book"
+	userBookUseCase "github.com/ryota1116/stacked_books/usecase/userbook"
 	"time"
 )
 
@@ -9,9 +10,29 @@ type UserBook struct {
 	Id        int
 	UserId    int
 	BookId    int
-	Status    int
-	Memo      string
+	Status    Status
+	Memo      Memo
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	Book      book.Book
+}
+
+// NewUserBook : コンストラクター
+func NewUserBook(command userBookUseCase.UserBookCreateCommand, book book.Book) (UserBook, error) {
+	status, err := NewStatus(command.UserBook.Status)
+	if err != nil {
+		return UserBook{}, err
+	}
+
+	memo, err := NewMemo(command.UserBook.Memo)
+	if err != nil {
+		return UserBook{}, err
+	}
+
+	return UserBook{
+		UserId: command.UserId,
+		BookId: book.Id,
+		Status: status,
+		Memo:   memo,
+	}, nil
 }

--- a/domain/model/userbook/user_book_repository.go
+++ b/domain/model/userbook/user_book_repository.go
@@ -1,10 +1,5 @@
 package userbook
 
-import (
-	"github.com/ryota1116/stacked_books/domain/model/book"
-)
-
 type UserBookRepository interface {
 	CreateOne(userBook UserBook) UserBook
-	FindAllByUserId(userId int) ([]book.Book, error)
 }

--- a/domain/model/userbook/user_book_repository.go
+++ b/domain/model/userbook/user_book_repository.go
@@ -1,5 +1,5 @@
 package userbook
 
 type UserBookRepository interface {
-	CreateOne(userBook UserBook) UserBook
+	Save(userBook UserBook) error
 }

--- a/infra/datasource/book/book_repository.go
+++ b/infra/datasource/book/book_repository.go
@@ -11,13 +11,23 @@ func NewBookPersistence() book.BookRepository {
 	return &bookPersistence{}
 }
 
-// FindOrCreateByGoogleBooksId : GoogleBooksIDからBookレコードを検索し、存在しなければ作成する
-func (bookPersistence) FindOrCreateByGoogleBooksId(GoogleBooksId string) book.Book {
+func (bookPersistence) FindOneByGoogleBooksId(GoogleBooksId string) (book.Book, error) {
 	db := datasource.DbConnect()
 	b := book.Book{}
-	db.Where("google_books_id = ?", GoogleBooksId).FirstOrCreate(&b)
 
-	return b
+	if err := db.Where("google_books_id = ?", GoogleBooksId).First(&b).Error; err != nil {
+		return b, err
+	}
+	return b, nil
+}
+
+func (bookPersistence) Save(book book.Book) error {
+	db := datasource.DbConnect()
+
+	if err := db.Create(&book).Error; err != nil {
+		return err
+	}
+	return nil
 }
 
 // FindAllByUserId : ログイン中のユーザーが登録している本の一覧を取得する

--- a/infra/datasource/book/book_repository.go
+++ b/infra/datasource/book/book_repository.go
@@ -2,7 +2,7 @@ package book
 
 import (
 	"github.com/ryota1116/stacked_books/domain/model/book"
-	"github.com/ryota1116/stacked_books/infra/persistence"
+	"github.com/ryota1116/stacked_books/infra/datasource"
 )
 
 type bookPersistence struct{}
@@ -13,7 +13,7 @@ func NewBookPersistence() book.BookRepository {
 
 // FindOrCreateByGoogleBooksId : GoogleBooksIDからBookレコードを検索し、存在しなければ作成する
 func (bookPersistence) FindOrCreateByGoogleBooksId(GoogleBooksId string) book.Book {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 	b := book.Book{}
 	db.Where("google_books_id = ?", GoogleBooksId).FirstOrCreate(&b)
 
@@ -22,7 +22,7 @@ func (bookPersistence) FindOrCreateByGoogleBooksId(GoogleBooksId string) book.Bo
 
 // FindAllByUserId : ログイン中のユーザーが登録している本の一覧を取得する
 func (bookPersistence) FindAllByUserId(userId int) ([]book.Book, error) {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 	var books []book.Book
 
 	// ユーザーが登録している本一覧を取得

--- a/infra/datasource/db_connect.go
+++ b/infra/datasource/db_connect.go
@@ -1,4 +1,4 @@
-package persistence
+package datasource
 
 import (
 	"fmt"

--- a/infra/datasource/user/user_repository.go
+++ b/infra/datasource/user/user_repository.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ryota1116/stacked_books/domain/model/user"
-	"github.com/ryota1116/stacked_books/infra/persistence"
+	"github.com/ryota1116/stacked_books/infra/datasource"
 )
 
 // Userのインフラ層の構造体
@@ -26,7 +26,7 @@ func NewUserPersistence() user.UserRepository {
 // }
 // インターフェイスの実装
 func (up userPersistence) Create(user user.User) (user.User, error) {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 
 	// TODO: playground/validationを使う
 	var err error
@@ -41,7 +41,7 @@ func (up userPersistence) Create(user user.User) (user.User, error) {
 }
 
 func (up userPersistence) FindOneByEmail(email string) (user.User, error) {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 
 	u := user.User{}
 	// emailでUserを取得
@@ -57,7 +57,7 @@ func (up userPersistence) FindOneByEmail(email string) (user.User, error) {
 
 // FindOne Userを1件取得
 func (up userPersistence) FindOne(userId int) user.User {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 
 	u := user.User{}
 	result := db.First(&u, userId)

--- a/infra/datasource/user/user_repository.go
+++ b/infra/datasource/user/user_repository.go
@@ -1,8 +1,6 @@
 package user
 
 import (
-	"errors"
-	"fmt"
 	"github.com/ryota1116/stacked_books/domain/model/user"
 	"github.com/ryota1116/stacked_books/infra/datasource"
 )
@@ -25,19 +23,21 @@ func NewUserPersistence() user.UserRepository {
 // 	関数の中身
 // }
 // インターフェイスの実装
-func (up userPersistence) Create(user user.User) (user.User, error) {
+func (up userPersistence) Create(user user.User) error {
 	db := datasource.DbConnect()
 
-	// TODO: playground/validationを使う
-	var err error
-	if user.UserName == "" {
-		err = errors.New("ユーザー名を入力してください")
-	}
+	// TODO: Domainに移す(DBの制約は必須だが最終防衛手段みたいなものなので
+	//       業務知識としてDomainに書くのがいい)
+	//var err error
+	//if user.UserName == "" {
+	//	err = errors.New("ユーザー名を入力してください")
+	//}
 
 	// DBにユーザーを登録
-	db.Create(&user)
-
-	return user, err
+	if err := db.Create(&user).Error; err != nil {
+		return err
+	}
+	return nil
 }
 
 func (up userPersistence) FindOneByEmail(email string) (user.User, error) {
@@ -56,13 +56,13 @@ func (up userPersistence) FindOneByEmail(email string) (user.User, error) {
 }
 
 // FindOne Userを1件取得
-func (up userPersistence) FindOne(userId int) user.User {
+func (up userPersistence) FindOne(userId int) (user.User, error) {
 	db := datasource.DbConnect()
 
 	u := user.User{}
-	result := db.First(&u, userId)
+	if err := db.First(&u, userId).Error; err != nil {
+		return u, err
+	}
 
-	fmt.Println(&result)
-
-	return u
+	return u, nil
 }

--- a/infra/datasource/userbook/user_book_repository.go
+++ b/infra/datasource/userbook/user_book_repository.go
@@ -12,9 +12,11 @@ func NewUserBookPersistence() userbook.UserBookRepository {
 }
 
 // CreateOne : UserBooksレコードを作成する
-func (userBookPersistence) CreateOne(userBook userbook.UserBook) userbook.UserBook {
+func (userBookPersistence) Save(userBook userbook.UserBook) error {
 	db := datasource.DbConnect()
-	db.Create(&userBook)
 
-	return userBook
+	if err := db.Create(&userBook).Error; err != nil {
+		return err
+	}
+	return nil
 }

--- a/infra/datasource/userbook/user_book_repository.go
+++ b/infra/datasource/userbook/user_book_repository.go
@@ -2,7 +2,7 @@ package userbook
 
 import (
 	"github.com/ryota1116/stacked_books/domain/model/userbook"
-	"github.com/ryota1116/stacked_books/infra/persistence"
+	"github.com/ryota1116/stacked_books/infra/datasource"
 )
 
 type userBookPersistence struct{}
@@ -13,7 +13,7 @@ func NewUserBookPersistence() userbook.UserBookRepository {
 
 // CreateOne : UserBooksレコードを作成する
 func (userBookPersistence) CreateOne(userBook userbook.UserBook) userbook.UserBook {
-	db := persistence.DbConnect()
+	db := datasource.DbConnect()
 	db.Create(&userBook)
 
 	return userBook

--- a/infra/externalapi/google-books-api/client.go
+++ b/infra/externalapi/google-books-api/client.go
@@ -2,26 +2,21 @@ package google_books_api
 
 import (
 	"encoding/json"
-	"fmt"
+	model "github.com/ryota1116/stacked_books/domain/model/searched_books/google_books_api"
 	"io/ioutil"
 	"net/http"
 )
 
-// URLForGoogleBooksAPI :
-const URLForGoogleBooksAPI = "https://www.googleapis.com/books/v1/volumes?q="
+const urlForGoogleBooksAPI = "https://www.googleapis.com/books/v1/volumes?q="
 
-type IGoogleBooksAPIClient interface {
-	SendRequest(searchWord string) (ResponseBodyFromGoogleBooksAPI, error)
-}
+type googleBooksApiClient struct{}
 
-type Client struct{}
-
-func NewClient() IGoogleBooksAPIClient {
-	return Client{}
+func NewClient() model.GoogleBooksApiClientInterface {
+	return googleBooksApiClient{}
 }
 
 // SendRequest : GoogleBooksAPIにリクエストを送信する
-func (client Client) SendRequest(searchWord string) (ResponseBodyFromGoogleBooksAPI, error) {
+func (client googleBooksApiClient) SendRequest(searchWord string) (model.ResponseBodyFromGoogleBooksApi, error) {
 	// TODO: 以下の方法で「文字列を連結してURLを生成」したいけど上手くいかない
 	//var byteURL = make([]byte, 0, 100) // 100byte のキャパシティを確保
 	//byteURL = append(byteURL, []byte(URLForGoogleBooksAPI))
@@ -29,14 +24,13 @@ func (client Client) SendRequest(searchWord string) (ResponseBodyFromGoogleBooks
 	//searchURL := string(byteURL)
 
 	// 文字列を連結してURLを生成
-	searchURL := URLForGoogleBooksAPI + searchWord
+	searchURL := urlForGoogleBooksAPI + searchWord
 
 	// GoogleBooksAPIを叩く
 	res, err := http.Get(searchURL)
 
 	if err != nil {
-		fmt.Println(err)
-		return ResponseBodyFromGoogleBooksAPI{}, err
+		// return ResponseBodyFromGoogleBooksAPI{}, err
 		// fmt.Errorf("Unable to get this url : http status %d", res.StatusCode)
 	}
 
@@ -49,15 +43,14 @@ func (client Client) SendRequest(searchWord string) (ResponseBodyFromGoogleBooks
 	// レスポンスボディを読み込む
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return ResponseBodyFromGoogleBooksAPI{}, err
+		// return model.ResponseBodyFromGoogleBooksAPI{}, err
 	}
 
 	// JSONエンコードされたデータをparseして、構造体に格納する
-	var responseFromGoogleBooksAPI ResponseBodyFromGoogleBooksAPI
-	if err := json.Unmarshal(body, &responseFromGoogleBooksAPI); err != nil {
-		return ResponseBodyFromGoogleBooksAPI{}, err
+	var responseBodyFromGoogleBooksApi model.ResponseBodyFromGoogleBooksApi
+	if err := json.Unmarshal(body, &responseBodyFromGoogleBooksApi); err != nil {
+		return model.ResponseBodyFromGoogleBooksApi{}, err
 	}
 
-	// レスポンスボディを返す
-	return responseFromGoogleBooksAPI, nil
+	return responseBodyFromGoogleBooksApi, nil
 }

--- a/infra/persistence/book/book_repository.go
+++ b/infra/persistence/book/book_repository.go
@@ -19,3 +19,19 @@ func (bookPersistence) FindOrCreateByGoogleBooksId(GoogleBooksId string) book.Bo
 
 	return b
 }
+
+// FindAllByUserId : ログイン中のユーザーが登録している本の一覧を取得する
+func (bookPersistence) FindAllByUserId(userId int) ([]book.Book, error) {
+	db := persistence.DbConnect()
+	var books []book.Book
+
+	// ユーザーが登録している本一覧を取得
+	if err := db.Joins("inner join user_books on books.id = user_books.book_id").
+		Joins("inner join users on user_books.user_id = ?", userId).
+		Group("books.id").
+		Find(&books).Error; err != nil {
+		return books, err
+	}
+
+	return books, nil
+}

--- a/infra/persistence/userbook/user_book_repository.go
+++ b/infra/persistence/userbook/user_book_repository.go
@@ -1,7 +1,6 @@
 package userbook
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/book"
 	"github.com/ryota1116/stacked_books/domain/model/userbook"
 	"github.com/ryota1116/stacked_books/infra/persistence"
 )
@@ -18,20 +17,4 @@ func (userBookPersistence) CreateOne(userBook userbook.UserBook) userbook.UserBo
 	db.Create(&userBook)
 
 	return userBook
-}
-
-// FindAllByUserId : ログイン中のユーザーが登録している本の一覧を取得する
-func (userBookPersistence) FindAllByUserId(userId int) ([]book.Book, error) {
-	db := persistence.DbConnect()
-	var books []book.Book
-
-	// ユーザーが登録している本一覧を取得
-	if err := db.Joins("inner join user_books on books.id = user_books.book_id").
-		Joins("inner join users on user_books.user_id = ?", userId).
-		Group("books.id").
-		Find(&books).Error; err != nil {
-		return books, err
-	}
-
-	return books, nil
 }

--- a/interfaces/api/handler/http/request/book/book_handler.go
+++ b/interfaces/api/handler/http/request/book/book_handler.go
@@ -57,7 +57,7 @@ func (bh bookHandler) SearchBooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 外部APIで書籍を検索
-	responseFromGoogleBooksAPI, err := bh.bookUseCase.SearchBooks(requestParameter.Title)
+	responseBodyFromGoogleBooksApi, err := bh.bookUseCase.SearchBooks(requestParameter.Title)
 	// 外部APIリクエストでエラーが発生した場合
 	if err != nil {
 		httpResponse.Return500Response(w, errors.New("検索に失敗しました"))
@@ -68,7 +68,7 @@ func (bh bookHandler) SearchBooks(w http.ResponseWriter, r *http.Request) {
 		StatusCode: http.StatusOK,
 		// GoogleBooksAPIのJSONレスポンスの構造体から、 書籍検索用のHTTPレスポンスボディ構造体を生成する
 		ResponseBody: book.SearchBooksResponseGenerator{
-			ResponseBodyFromGoogleBooksAPI: responseFromGoogleBooksAPI,
+			ResponseBodyFromGoogleBooksApi: responseBodyFromGoogleBooksApi,
 		}.Execute(),
 	}.ReturnResponse(w)
 }

--- a/interfaces/api/handler/http/request/book/book_handler_test.go
+++ b/interfaces/api/handler/http/request/book/book_handler_test.go
@@ -3,7 +3,7 @@ package book
 import (
 	"encoding/json"
 	"github.com/magiconair/properties/assert"
-	"github.com/ryota1116/stacked_books/domain/model/google-books-api"
+	"github.com/ryota1116/stacked_books/infra/externalapi/google-books-api"
 	res "github.com/ryota1116/stacked_books/interfaces/api/handler/http/response"
 	"github.com/ryota1116/stacked_books/tests/test_assertion"
 	"io/ioutil"

--- a/interfaces/api/handler/http/request/user/user_handler.go
+++ b/interfaces/api/handler/http/request/user/user_handler.go
@@ -112,15 +112,20 @@ func (uh userHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 }
 
 func (uh userHandler) ShowUser(w http.ResponseWriter, r *http.Request) {
-	user := modelUser.User{}
-	err := json.NewDecoder(r.Body).Decode(&user)
+	user1 := modelUser.User{}
+	err := json.NewDecoder(r.Body).Decode(&user1)
 	if err != nil {
 		return
 	}
 
-	user = uh.userUseCase.FindOne(user.Id)
+	userDto, err := uh.userUseCase.FindOne(user1.Id)
+	if err != nil {
+		httpResponse.Return500Response(w, err)
+		return
+	}
 
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(user)
+	httpResponse.Response{
+		StatusCode:   http.StatusOK,
+		ResponseBody: userDto,
+	}.ReturnResponse(w)
 }

--- a/interfaces/api/handler/http/request/user_book/register_user_books/form_validator.go
+++ b/interfaces/api/handler/http/request/user_book/register_user_books/form_validator.go
@@ -1,8 +1,6 @@
 package RegisterUserBooks
 
 import (
-	"fmt"
-	"github.com/ryota1116/stacked_books/domain/model/userbook"
 	"github.com/ryota1116/stacked_books/interfaces/api/handler/http/response"
 	"unicode/utf8"
 )
@@ -29,23 +27,6 @@ func (rbh FormValidator) Validate() (bool, response.ErrorResponseBody) {
 
 	if rbh.RequestBody.Book.PageCount <= 0 {
 		return false, response.ErrorResponseBody{Message: "本のページ数は1ページ以上で入力してください。"}
-	}
-
-	// Contain関数を作成する https://zenn.dev/glassonion1/articles/7c7830a269909c
-	isValidStatus := func() bool {
-		for _, bookStatus := range userbook.GetBookStatuses() {
-			if rbh.RequestBody.UserBook.Status == bookStatus {
-				return true
-			}
-		}
-		return false
-	}
-
-	if !isValidStatus() {
-		return isValidStatus(), response.ErrorResponseBody{Message: fmt.Sprintf(
-			"読書ステータスの値が不正です。 status: %d",
-			rbh.RequestBody.UserBook.Status),
-		}
 	}
 
 	memoCount := utf8.RuneCountInString(rbh.RequestBody.UserBook.Memo)

--- a/interfaces/api/handler/http/request/user_book/user_book_handler.go
+++ b/interfaces/api/handler/http/request/user_book/user_book_handler.go
@@ -57,7 +57,11 @@ func (ubh userBookHandler) RegisterUserBook(w http.ResponseWriter, r *http.Reque
 	}
 
 	// ログイン中のユーザーを取得する
-	currentUser := ubh.userSessionHandlerMiddleWare.CurrentUser(r)
+	currentUser, err := ubh.userSessionHandlerMiddleWare.CurrentUser(r)
+	if err != nil {
+		httpResponse.Return500Response(w, err)
+		return
+	}
 
 	command := userBookUseCase.UserBookCreateCommand{
 		UserId: currentUser.Id,
@@ -79,7 +83,11 @@ func (ubh userBookHandler) RegisterUserBook(w http.ResponseWriter, r *http.Reque
 	}
 
 	// UserBooksレコードを作成する
-	bookDto, userBookDto := ubh.userBookUseCase.RegisterUserBook(command)
+	bookDto, userBookDto, err := ubh.userBookUseCase.RegisterUserBook(command)
+	if err != nil {
+		httpResponse.Return500Response(w, err)
+		return
+	}
 
 	httpResponse.Response{
 		StatusCode: http.StatusOK,
@@ -94,9 +102,13 @@ func (ubh userBookHandler) RegisterUserBook(w http.ResponseWriter, r *http.Reque
 func (ubh userBookHandler) FindUserBooks(w http.ResponseWriter, r *http.Request) {
 	// セッション情報からUserを取得
 	ushm := middleware.NewUserSessionHandlerMiddleWare()
-	user := ushm.CurrentUser(r)
+	currentUser, err := ushm.CurrentUser(r)
+	if err != nil {
+		httpResponse.Return500Response(w, err)
+		return
+	}
 
-	booksDto, err := ubh.userBookUseCase.FindUserBooksByUserId(user.Id)
+	booksDto, err := ubh.userBookUseCase.FindUserBooksByUserId(currentUser.Id)
 	if err != nil {
 		httpResponse.Return500Response(w, err)
 		return

--- a/interfaces/api/handler/http/response/book/search_books_response.go
+++ b/interfaces/api/handler/http/response/book/search_books_response.go
@@ -1,10 +1,12 @@
 package book
 
-import "github.com/ryota1116/stacked_books/domain/model/google-books-api"
+import (
+	model "github.com/ryota1116/stacked_books/domain/model/searched_books/google_books_api"
+)
 
 // SearchBooksResponseGenerator : 書籍検索用レスポンスボディのジェネレーター
 type SearchBooksResponseGenerator struct {
-	ResponseBodyFromGoogleBooksAPI google_books_api.ResponseBodyFromGoogleBooksAPI `json:"response_body_from_google_books_api"`
+	ResponseBodyFromGoogleBooksApi model.ResponseBodyFromGoogleBooksApi `json:"response_body_from_google_books_api"`
 }
 
 // SearchBooksResponses : 書籍検索用のレスポンスボディ構造体のコレクション
@@ -37,7 +39,7 @@ func (sbrg SearchBooksResponseGenerator) Execute() SearchBooksResponses {
 
 	// GoogleBooksAPIのJSONレスポンスから、書籍検索用のレスポンスボディ構造体を生成する
 	// 検索結果一覧が配列で返ってくるため、slice型に格納して返す
-	for _, item := range sbrg.ResponseBodyFromGoogleBooksAPI.Items {
+	for _, item := range sbrg.ResponseBodyFromGoogleBooksApi.Items {
 		searchBooksResponse := SearchBooksResponse{
 			GoogleBooksId: item.ID,
 			Title:         item.VolumeInfo.Title,

--- a/interfaces/api/handler/http/response/book/search_books_response_generator_test.go
+++ b/interfaces/api/handler/http/response/book/search_books_response_generator_test.go
@@ -3,7 +3,7 @@ package book
 import (
 	"encoding/json"
 	"github.com/google/go-cmp/cmp"
-	"github.com/ryota1116/stacked_books/domain/model/google-books-api"
+	"github.com/ryota1116/stacked_books/infra/externalapi/google-books-api"
 	"testing"
 )
 

--- a/interfaces/api/handler/http/response/user_book/find_user_books/response.go
+++ b/interfaces/api/handler/http/response/user_book/find_user_books/response.go
@@ -1,18 +1,19 @@
 package find_user_books
 
 import (
-	"github.com/ryota1116/stacked_books/usecase/userbook"
+	"github.com/ryota1116/stacked_books/usecase/book"
 )
 
 type FindUserBooksResponseGenerator struct {
-	UserBooksDto []userbook.UserBookDto
+	BooksDto []book.BookDto
 }
 
 type FindUserBooksResponse struct {
-	UserBooks []UserBook `json:"user_books"`
+	Books []Book `json:"books"`
 }
 
-type UserBook struct {
+// TODO
+type Book struct {
 	ID             int    `json:"id"`
 	GoogleBooksId  string `json:"google_books_id"`
 	Title          string `json:"title"`
@@ -28,24 +29,24 @@ type UserBook struct {
 }
 
 func (fubrg FindUserBooksResponseGenerator) Execute() FindUserBooksResponse {
-	var userBooks []UserBook
+	var books []Book
 
-	for _, userBookDto := range fubrg.UserBooksDto {
-		userBook := UserBook{
-			ID:             userBookDto.ID,
-			GoogleBooksId:  userBookDto.GoogleBooksId,
-			Title:          userBookDto.Title,
-			Description:    userBookDto.Description,
-			Isbn10:         userBookDto.Isbn10,
-			Isbn13:         userBookDto.Isbn13,
-			PageCount:      userBookDto.PageCount,
-			PublishedYear:  userBookDto.PublishedYear,
-			PublishedMonth: userBookDto.PublishedMonth,
-			PublishedDate:  userBookDto.PublishedDate,
+	for _, bookDto := range fubrg.BooksDto {
+		userBook := Book{
+			ID:             bookDto.Id,
+			GoogleBooksId:  bookDto.GoogleBooksId,
+			Title:          bookDto.Title,
+			Description:    bookDto.Description,
+			Isbn10:         *bookDto.Isbn_10,
+			Isbn13:         *bookDto.Isbn_13,
+			PageCount:      *bookDto.PageCount,
+			PublishedYear:  *bookDto.PublishedYear,
+			PublishedMonth: *bookDto.PublishedMonth,
+			PublishedDate:  *bookDto.PublishedDate,
 		}
 
-		userBooks = append(userBooks, userBook)
+		books = append(books, userBook)
 	}
 
-	return FindUserBooksResponse{UserBooks: userBooks}
+	return FindUserBooksResponse{Books: books}
 }

--- a/interfaces/api/handler/http/response/user_book/register_user_book_response.go
+++ b/interfaces/api/handler/http/response/user_book/register_user_book_response.go
@@ -1,21 +1,16 @@
 package user_book
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/book"
-	"github.com/ryota1116/stacked_books/domain/model/userbook"
+	"github.com/ryota1116/stacked_books/usecase/book"
+	"github.com/ryota1116/stacked_books/usecase/userbook"
 )
 
 type RegisterUserBookResponseGenerator struct {
-	book.Book
-	userbook.UserBook
+	BookDto     book.BookDto
+	UserBookDto userbook.UserBookDto
 }
 
 type RegisterUserBookResponse struct {
-	Book     Book     `json:"userbook"`
-	UserBook UserBook `json:"userbook"`
-}
-
-type Book struct {
 	GoogleBooksId  string `json:"google_books_id"`
 	Title          string `json:"title"`
 	Description    string `json:"description"`
@@ -25,30 +20,23 @@ type Book struct {
 	PublishedYear  int    `json:"published_year"`
 	PublishedMonth int    `json:"published_month"`
 	PublishedDate  int    `json:"published_date"`
-}
-
-type UserBook struct {
-	Status int    `json:"status"`
-	Memo   string `json:"memo"`
+	Status         int    `json:"status"`
+	Memo           string `json:"memo"`
 }
 
 // Execute : 書籍登録用のレスポンス構造体を生成する
 func (rubrg RegisterUserBookResponseGenerator) Execute() RegisterUserBookResponse {
 	return RegisterUserBookResponse{
-		Book: Book{
-			GoogleBooksId:  rubrg.Book.GoogleBooksId,
-			Title:          rubrg.Book.Title,
-			Description:    rubrg.Book.Description,
-			Isbn10:         rubrg.Book.Isbn_10,
-			Isbn13:         rubrg.Book.Isbn_13,
-			PageCount:      rubrg.Book.PageCount,
-			PublishedYear:  rubrg.Book.PublishedYear,
-			PublishedMonth: rubrg.Book.PublishedMonth,
-			PublishedDate:  rubrg.Book.PublishedDate,
-		},
-		UserBook: UserBook{
-			Status: rubrg.UserBook.Status,
-			Memo:   rubrg.UserBook.Memo,
-		},
+		GoogleBooksId:  rubrg.BookDto.GoogleBooksId,
+		Title:          rubrg.BookDto.Title,
+		Description:    rubrg.BookDto.Description,
+		Isbn10:         *rubrg.BookDto.Isbn_10,
+		Isbn13:         *rubrg.BookDto.Isbn_13,
+		PageCount:      *rubrg.BookDto.PageCount,
+		PublishedYear:  *rubrg.BookDto.PublishedYear,
+		PublishedMonth: *rubrg.BookDto.PublishedMonth,
+		PublishedDate:  *rubrg.BookDto.PublishedDate,
+		Status:         rubrg.UserBookDto.Status,
+		Memo:           rubrg.UserBookDto.Memo,
 	}
 }

--- a/interfaces/api/handler/middleware/user_session_handler_middleware.go
+++ b/interfaces/api/handler/middleware/user_session_handler_middleware.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/dgrijalva/jwt-go/request"
-	user3 "github.com/ryota1116/stacked_books/domain/model/user"
 	user2 "github.com/ryota1116/stacked_books/infra/datasource/user"
 	"github.com/ryota1116/stacked_books/usecase/user"
 	"net/http"
@@ -62,7 +61,7 @@ func VerifyUserToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // CurrentUser : セッションからログイン中のユーザー情報を取得する
-func (userSessionHandlerMiddleWare) CurrentUser(r *http.Request) user3.User {
+func (userSessionHandlerMiddleWare) CurrentUser(r *http.Request) (user.UserDto, error) {
 	// ParseFromRequestでリクエストヘッダーのAuthorizationからJWTを抽出し、抽出したJWTのclaimをparseしてくれる。
 	parsedToken, err := request.ParseFromRequest(r, request.AuthorizationHeaderExtractor, func(token *jwt.Token) (interface{}, error) {
 		_, ok := token.Method.(*jwt.SigningMethodHMAC) // 署名アルゴリズムにHS256を使用しているかチェック
@@ -90,7 +89,9 @@ func (userSessionHandlerMiddleWare) CurrentUser(r *http.Request) user3.User {
 			return userUseCase.FindOne(1)
 		}
 	}
-	return user3.User{}
+
+	// この処理に入る = エラーということ(つまりerrをnilで返してはいけない)
+	return user.UserDto{}, err
 }
 
 func SetUserSession(w http.ResponseWriter, user user.UserDto) {

--- a/interfaces/api/handler/middleware/user_session_handler_middleware.go
+++ b/interfaces/api/handler/middleware/user_session_handler_middleware.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/dgrijalva/jwt-go/request"
 	user3 "github.com/ryota1116/stacked_books/domain/model/user"
-	user2 "github.com/ryota1116/stacked_books/infra/persistence/user"
+	user2 "github.com/ryota1116/stacked_books/infra/datasource/user"
 	"github.com/ryota1116/stacked_books/usecase/user"
 	"net/http"
 	"strconv"

--- a/interfaces/api/handler/middleware/user_session_handler_middleware_interface.go
+++ b/interfaces/api/handler/middleware/user_session_handler_middleware_interface.go
@@ -1,10 +1,10 @@
 package middleware
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/user"
+	"github.com/ryota1116/stacked_books/usecase/user"
 	"net/http"
 )
 
 type UserSessionHandlerMiddleWareInterface interface {
-	CurrentUser(*http.Request) user.User
+	CurrentUser(*http.Request) (user.UserDto, error)
 }

--- a/server/router.go
+++ b/server/router.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"github.com/gorilla/mux"
-	"github.com/ryota1116/stacked_books/domain/model/google-books-api"
-	book2 "github.com/ryota1116/stacked_books/infra/persistence/book"
-	user2 "github.com/ryota1116/stacked_books/infra/persistence/user"
-	userbook2 "github.com/ryota1116/stacked_books/infra/persistence/userbook"
+	book2 "github.com/ryota1116/stacked_books/infra/datasource/book"
+	user2 "github.com/ryota1116/stacked_books/infra/datasource/user"
+	userbook2 "github.com/ryota1116/stacked_books/infra/datasource/userbook"
+	"github.com/ryota1116/stacked_books/infra/externalapi/google-books-api"
 	book3 "github.com/ryota1116/stacked_books/interfaces/api/handler/http/request/book"
 	user3 "github.com/ryota1116/stacked_books/interfaces/api/handler/http/request/user"
 	"github.com/ryota1116/stacked_books/interfaces/api/handler/http/request/user_book"

--- a/usecase/book/book_dto.go
+++ b/usecase/book/book_dto.go
@@ -1,0 +1,39 @@
+package book
+
+import model "github.com/ryota1116/stacked_books/domain/model/book"
+
+type BookDtoGenerator struct {
+	Book model.Book
+}
+
+type BookDto struct {
+	Id             int
+	GoogleBooksId  string
+	Title          string
+	Description    string
+	Image          *string
+	Isbn_10        *string
+	Isbn_13        *string
+	PageCount      *int
+	PublishedYear  *int
+	PublishedMonth *int
+	PublishedDate  *int
+}
+
+func (dtog BookDtoGenerator) Execute() BookDto {
+	var bookDto = BookDto{
+		Id:             dtog.Book.Id,
+		GoogleBooksId:  dtog.Book.GoogleBooksId,
+		Title:          dtog.Book.Title,
+		Description:    dtog.Book.Description,
+		Image:          &dtog.Book.Image,
+		Isbn_10:        &dtog.Book.Isbn_10,
+		Isbn_13:        &dtog.Book.Isbn_13,
+		PageCount:      &dtog.Book.PageCount,
+		PublishedYear:  &dtog.Book.PublishedYear,
+		PublishedMonth: &dtog.Book.PublishedMonth,
+		PublishedDate:  &dtog.Book.PublishedDate,
+	}
+
+	return bookDto
+}

--- a/usecase/book/book_usecase.go
+++ b/usecase/book/book_usecase.go
@@ -1,27 +1,27 @@
 package book
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/google-books-api"
+	model "github.com/ryota1116/stacked_books/domain/model/searched_books/google_books_api"
 )
 
 type BookUseCaseInterface interface {
-	SearchBooks(title string) (google_books_api.ResponseBodyFromGoogleBooksAPI, error)
+	SearchBooks(title string) (model.ResponseBodyFromGoogleBooksApi, error)
 }
 
 type bookUseCase struct {
 	// BookRepositoryを使う必要が出たときにコメントアウト外す
 	// bookRepository repository.BookRepository
-	googleBooksAPIClient google_books_api.IGoogleBooksAPIClient
+	googleBooksAPIClient model.GoogleBooksApiClientInterface
 }
 
-func NewBookUseCase(client google_books_api.IGoogleBooksAPIClient) BookUseCaseInterface {
+func NewBookUseCase(client model.GoogleBooksApiClientInterface) BookUseCaseInterface {
 	return &bookUseCase{
 		client,
 	}
 }
 
 // SearchBooks : 外部APIを用いて書籍検索を行う
-func (bu bookUseCase) SearchBooks(title string) (google_books_api.ResponseBodyFromGoogleBooksAPI, error) {
+func (bu bookUseCase) SearchBooks(title string) (model.ResponseBodyFromGoogleBooksApi, error) {
 	// 外部APIで書籍を検索
 	// 書籍検索用のレスポンスボディ構造体のスライス型
 	responseFromGoogleBooksAPI, err := bu.googleBooksAPIClient.SendRequest(title)

--- a/usecase/book/book_usecase_test.go
+++ b/usecase/book/book_usecase_test.go
@@ -2,7 +2,7 @@ package book
 
 import (
 	"github.com/magiconair/properties/assert"
-	"github.com/ryota1116/stacked_books/domain/model/google-books-api"
+	"github.com/ryota1116/stacked_books/infra/externalapi/google-books-api"
 	"os"
 	"testing"
 )

--- a/usecase/user/user_usecase.go
+++ b/usecase/user/user_usecase.go
@@ -58,13 +58,13 @@ func (uu userUseCase) SignUp(command UserCreateCommand) (UserDto, error) {
 
 // SignIn 「emailで取得したUserのpassword(ハッシュ化されている)」と「クライアントのpassword入力値」を比較する
 func (uu userUseCase) SignIn(email string, password string) (UserDto, error) {
-	dbUser, err := uu.userRepository.FindOneByEmail(email)
+	user, err := uu.userRepository.FindOneByEmail(email)
 
 	userDto := UserDtoGenerator{
-		User: dbUser,
+		User: user,
 	}.Execute()
 
-	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password)); err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
 		fmt.Println("ログインできませんでした") // レスポンスボディに入れる文字列を返すようにする
 		return userDto, err
 	} else {

--- a/usecase/user/user_usecase.go
+++ b/usecase/user/user_usecase.go
@@ -16,7 +16,7 @@ const (
 type UserUseCase interface {
 	SignUp(command UserCreateCommand) (UserDto, error)
 	SignIn(email string, password string) (UserDto, error)
-	FindOne(userId int) user.User
+	FindOne(userId int) (UserDto, error)
 }
 
 // TODO: 依存する方向てきな？
@@ -47,10 +47,10 @@ func (uu userUseCase) SignUp(command UserCreateCommand) (UserDto, error) {
 		Password: string(bcryptHashPassword),
 	}
 
-	savedUser, err := uu.userRepository.Create(u)
+	err = uu.userRepository.Create(u)
 
 	userDto := UserDtoGenerator{
-		User: savedUser,
+		User: u,
 	}.Execute()
 
 	return userDto, err
@@ -74,8 +74,15 @@ func (uu userUseCase) SignIn(email string, password string) (UserDto, error) {
 	return userDto, err
 }
 
-func (uu userUseCase) FindOne(userId int) user.User {
-	return uu.userRepository.FindOne(userId)
+func (uu userUseCase) FindOne(userId int) (UserDto, error) {
+	user, err := uu.userRepository.FindOne(userId)
+	if err != nil {
+		return UserDto{}, err
+	}
+
+	return UserDtoGenerator{
+		User: user,
+	}.Execute(), nil
 }
 
 // GenerateToken : 最後の返り値をerror型(インターフェイス)にすることで、エラーの有無を返す。Goは例外処理が無いため、多値で返すのが基本

--- a/usecase/userbook/user_book_dto.go
+++ b/usecase/userbook/user_book_dto.go
@@ -24,8 +24,8 @@ func (dtog UserBookDtoGenerator) Execute() UserBookDto {
 		Id:        dtog.UserBook.Id,
 		UserId:    dtog.UserBook.UserId,
 		BookId:    dtog.UserBook.BookId,
-		Status:    dtog.UserBook.Status,
-		Memo:      dtog.UserBook.Memo,
+		Status:    dtog.UserBook.Status.Value,
+		Memo:      dtog.UserBook.Memo.Value,
 		CreatedAt: dtog.UserBook.CreatedAt,
 		UpdatedAt: dtog.UserBook.UpdatedAt,
 	}

--- a/usecase/userbook/user_book_dto.go
+++ b/usecase/userbook/user_book_dto.go
@@ -1,47 +1,32 @@
 package userbook
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/book"
+	"github.com/ryota1116/stacked_books/domain/model/userbook"
+	"time"
 )
 
-type DtoGenerator struct {
-	Books []book.Book
+type UserBookDtoGenerator struct {
+	UserBook userbook.UserBook
 }
 
 type UserBookDto struct {
-	ID             int
-	GoogleBooksId  string
-	Title          string
-	Description    string
-	Isbn10         string
-	Isbn13         string
-	PageCount      int
-	PublishedYear  int
-	PublishedMonth int
-	PublishedDate  int
-	//Status int
-	//Memo   string
+	Id        int
+	UserId    int
+	BookId    int
+	Status    int
+	Memo      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
-func (dto DtoGenerator) Execute() []UserBookDto {
-	var booksDto []UserBookDto
-
-	for _, b := range dto.Books {
-		dto := UserBookDto{
-			ID:             b.Id,
-			GoogleBooksId:  b.GoogleBooksId,
-			Title:          b.Title,
-			Description:    b.Description,
-			Isbn10:         b.Isbn_10,
-			Isbn13:         b.Isbn_13,
-			PageCount:      b.PageCount,
-			PublishedYear:  b.PublishedYear,
-			PublishedMonth: b.PublishedMonth,
-			PublishedDate:  b.PublishedDate,
-		}
-
-		booksDto = append(booksDto, dto)
+func (dtog UserBookDtoGenerator) Execute() UserBookDto {
+	return UserBookDto{
+		Id:        dtog.UserBook.Id,
+		UserId:    dtog.UserBook.UserId,
+		BookId:    dtog.UserBook.BookId,
+		Status:    dtog.UserBook.Status,
+		Memo:      dtog.UserBook.Memo,
+		CreatedAt: dtog.UserBook.CreatedAt,
+		UpdatedAt: dtog.UserBook.UpdatedAt,
 	}
-
-	return booksDto
 }

--- a/usecase/userbook/user_book_usecase.go
+++ b/usecase/userbook/user_book_usecase.go
@@ -1,21 +1,22 @@
 package userbook
 
 import (
-	"github.com/ryota1116/stacked_books/domain/model/book"
+	model "github.com/ryota1116/stacked_books/domain/model/book"
 	"github.com/ryota1116/stacked_books/domain/model/userbook"
+	"github.com/ryota1116/stacked_books/usecase/book"
 )
 
 type UserBookUseCase interface {
-	RegisterUserBook(command UserBookCreateCommand) (book.Book, userbook.UserBook)
-	FindUserBooksByUserId(userId int) ([]UserBookDto, error)
+	RegisterUserBook(command UserBookCreateCommand) (book.BookDto, UserBookDto)
+	FindUserBooksByUserId(userId int) ([]book.BookDto, error)
 }
 
 type userBookUseCase struct {
-	bookRepository     book.BookRepository
+	bookRepository     model.BookRepository
 	userBookRepository userbook.UserBookRepository
 }
 
-func NewUserBookUseCase(br book.BookRepository, ubr userbook.UserBookRepository) UserBookUseCase {
+func NewUserBookUseCase(br model.BookRepository, ubr userbook.UserBookRepository) UserBookUseCase {
 	return &userBookUseCase{
 		bookRepository:     br,
 		userBookRepository: ubr,
@@ -23,7 +24,7 @@ func NewUserBookUseCase(br book.BookRepository, ubr userbook.UserBookRepository)
 }
 
 // RegisterUserBook : UserBooksレコードを作成する
-func (ubu userBookUseCase) RegisterUserBook(command UserBookCreateCommand) (book.Book, userbook.UserBook) {
+func (ubu userBookUseCase) RegisterUserBook(command UserBookCreateCommand) (book.BookDto, UserBookDto) {
 	// GoogleBooksIDからBookレコードを検索し、存在しなければ作成する
 	b := ubu.bookRepository.FindOrCreateByGoogleBooksId(command.Book.GoogleBooksId)
 
@@ -37,15 +38,21 @@ func (ubu userBookUseCase) RegisterUserBook(command UserBookCreateCommand) (book
 	// UserBooksレコードを作成する
 	savedUserBook := ubu.userBookRepository.CreateOne(userBook)
 
-	return b, savedUserBook
+	return book.BookDtoGenerator{Book: b}.Execute(),
+		UserBookDtoGenerator{UserBook: savedUserBook}.Execute()
 }
 
 // FindUserBooksByUserId : ログイン中のユーザーが登録している本の一覧を取得する
-func (ubu userBookUseCase) FindUserBooksByUserId(userId int) ([]UserBookDto, error) {
-	books, err := ubu.userBookRepository.FindAllByUserId(userId)
+func (ubu userBookUseCase) FindUserBooksByUserId(userId int) ([]book.BookDto, error) {
+	books, err := ubu.bookRepository.FindAllByUserId(userId)
 
 	// DTOに変換
-	userBooks := DtoGenerator{Books: books}.Execute()
+	var booksDto []book.BookDto
+	for _, b := range books {
+		dtog := book.BookDtoGenerator{Book: b}
 
-	return userBooks, err
+		booksDto = append(booksDto, dtog.Execute())
+	}
+
+	return booksDto, err
 }

--- a/usecase/userbook/user_book_usecase.go
+++ b/usecase/userbook/user_book_usecase.go
@@ -45,11 +45,9 @@ func (ubu userBookUseCase) RegisterUserBook(command UserBookCreateCommand) (book
 		}
 	}
 
-	userBook := userbook.UserBook{
-		UserId: command.UserId,
-		BookId: b.Id,
-		Status: command.UserBook.Status,
-		Memo:   command.UserBook.Memo,
+	userBook, err := userbook.NewUserBook(command, b)
+	if err != nil {
+		return book.BookDto{}, UserBookDto{}, err
 	}
 
 	// UserBooksレコードを作成する

--- a/usecase/userbook/user_book_usecase_test.go
+++ b/usecase/userbook/user_book_usecase_test.go
@@ -10,33 +10,31 @@ import (
 
 type BookRepositoryMock struct{}
 
-func (BookRepositoryMock) FindOrCreateByGoogleBooksId(string) book.Book {
-	return book.Book{
-		GoogleBooksId:  "Wx1dLwEACAAJ",
-		Title:          "リーダブルコード",
-		Description:    "読んでわかるコードの重要性と方法について解説",
-		Isbn_10:        "4873115655",
-		Isbn_13:        "9784873115658",
-		PageCount:      237,
-		PublishedYear:  2012,
-		PublishedMonth: 6,
-		PublishedDate:  0,
-	}
-}
-
 type UserBookRepositoryMock struct{}
 
-func (UserBookRepositoryMock) CreateOne(userbook.UserBook) userbook.UserBook {
-	return userbook.UserBook{
-		Id:     1,
-		UserId: 1,
-		BookId: 1,
-		Status: 1,
-		Memo:   "メモメモメモ",
+func (BookRepositoryMock) FindOneByGoogleBooksId(GoogleBooksId string) book.Book {
+	return book.Book{
+		Id:             1,
+		GoogleBooksId:  "test",
+		Title:          "タイトル",
+		Description:    "説明文です",
+		Image:          "",
+		Isbn_10:        "",
+		Isbn_13:        "",
+		PageCount:      100,
+		PublishedYear:  2022,
+		PublishedMonth: 8,
+		PublishedDate:  10,
+		CreatedAt:      time.Date(2022, time.August, 10, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2022, time.August, 10, 12, 0, 0, 0, time.UTC),
 	}
 }
 
-func (UserBookRepositoryMock) FindAllByUserId(int) ([]book.Book, error) {
+func (BookRepositoryMock) Save(book2 book.Book) error {
+	return nil
+}
+
+func (BookRepositoryMock) FindAllByUserId(int) ([]book.Book, error) {
 	var books []book.Book
 	books = append(books, book.Book{
 		Id:             1,
@@ -55,6 +53,10 @@ func (UserBookRepositoryMock) FindAllByUserId(int) ([]book.Book, error) {
 	})
 
 	return books, nil
+}
+
+func (UserBookRepositoryMock) Save(userbook.UserBook) error {
+	return nil
 }
 
 // UserBookUseCaseのRegisterUserBookの正常系テスト
@@ -80,7 +82,7 @@ func TestUserBookUseCaseRegisterUserBook(t *testing.T) {
 	}
 
 	// userBookUseCaseのRegisterUserBookを実行
-	book, userBook := ubu.RegisterUserBook(command)
+	book, userBook, _ := ubu.RegisterUserBook(command)
 
 	// 戻り値である構造体が正しいことをテスト
 	if diff := cmp.Diff(book, expectedBook); diff != "" {


### PR DESCRIPTION
## DTOとか使ってない箇所を修正

## 外部API(Google Books API)の実装をリポジトリパターンで抽象化
- 外部APIを使うにあたり
    - **インフラ層 : 外部サービスから取得した値を (ドメイン層に定義した)構造体に変換して返す**
    - **ドメイン層 : (ドメイン層に定義した)構造体をレシーバーとするメソッド(ビジネスロジック)を記述する**
        - 今回のケースにおいては用意したいビジネスロジックは存在しなかった。

という構成にした。

### 参考URL
- [DDDにおける外部サービスの抽象化](https://nametake.github.io/posts/2020/07/25/abstract-external-service/)
- [外部APIは、内部のDBのデータとは振る舞いが大きく異なるので、通常の集約とは分けた方が良いと思います。(続) - 質問箱](https://twitter.com/little_hand_s/status/1397675107443613697)
- [個人的に戦術的DDDの実装パターンと相性が悪いと思ったGoの仕様と理由 - zenn](https://zenn.dev/msksgm/articles/20220617-go-is-incompatible-to-ddd)
- https://github.com/ryota1116/stacked_books/pull/13