### PR TITLE
CIでgo buildを実行した際に発生するエラーを解消

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         go-version: 1.17
 
+    - name: Tidy Modules
+      run: go mod tidy
+
     - name: Build
       run: go build -v ./...
 

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang-migrate/migrate v3.5.4+incompatible
-	github.com/google/go-cmp v0.5.5
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/magiconair/properties v1.8.4
+	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.1.0

--- a/interfaces/api/handler/http/request/user/user_handler_test.go
+++ b/interfaces/api/handler/http/request/user/user_handler_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 )
 
-// モックを導入
 type UserUseCaseMock struct {
 }
 


### PR DESCRIPTION
## 概要

### 発生した事象
- CIで`go build`を実行した際に以下エラーで落ちていた。
    - https://github.com/ryota1116/stacked_books/actions/runs/5798417971/job/15716114878#step:4:11

```
Run go build -v ./...
go: github.com/containerd/containerd@v1.5.18: missing go.sum entry; to add it:
	go mod download github.com/containerd/containerd
go: github.com/containerd/containerd@v1.5.1[8](https://github.com/ryota1116/stacked_books/actions/runs/5798417971/job/15716114878#step:4:9): missing go.sum entry; to add it:
	go mod download github.com/containerd/containerd
```

### 原因
- go.sumに必要なモジュールが載っていないことでエラーになっていた。

### 対策
- CIでgo buildの前にgo mod tidyを実行することでgo.sumを更新するようにした。
    - go mod tidyは「**go.modを確認し不足しているエントリをgo.sumに追加する**」「プロジェクト内で使用されていない依存関係（go.mod ファイルにリストされているが実際にコード内で使用されていないもの）をgo.modファイルから削除する」といったことをしてくれる。

## 本PRマージ後のCI
- 無事Ciが通ってくれた🎉
    - https://github.com/ryota1116/stacked_books/actions/runs/5799027361

## 関連URL
- https://dev.classmethod.jp/articles/go-build-failed-with-missing-go-sum-entry-for-module-providing-package/
- https://qiita.com/moritaoy/items/71b3571e3e68e11d6b2e
